### PR TITLE
gfortran: libquadmath is not available everywhere

### DIFF
--- a/org.freedesktop.Sdk.Extension.gfortran-62.json
+++ b/org.freedesktop.Sdk.Extension.gfortran-62.json
@@ -77,7 +77,8 @@
                     "type": "script",
                     "commands": [
                         "mkdir -p /app/lib",
-                        "cp -P /usr/lib/sdk/gfortran-62/lib/libquadmath.so* /usr/lib/sdk/gfortran-62/lib/libgfortran.so* /app/lib/"
+                        "if [ -e /usr/lib/sdk/gfortran-62/lib/libquadmath.so ]; then cp -P /usr/lib/sdk/gfortran-62/lib/libquadmath.so* /app/lib; fi",
+                        "cp -P /usr/lib/sdk/gfortran-62/lib/libgfortran.so* /app/lib/"
                     ],
                     "dest-filename": "install.sh"
                 },


### PR DESCRIPTION
Fix ported from https://github.com/flatpak/freedesktop-sdk-images/pull/107

@cosimoc 